### PR TITLE
docs: Fix api.py pause, pause_all description.

### DIFF
--- a/src/aria2p/api.py
+++ b/src/aria2p/api.py
@@ -499,10 +499,10 @@ class API:
 
     def pause(self, downloads: List[Download], force: bool = False) -> List[OperationResult]:
         """
-        Remove the given downloads from the list.
+        Pause (active) the given downloads.
 
         Arguments:
-            downloads: The list of downloads to remove.
+            downloads: The list of downloads to pause.
             force: Whether to pause immediately without contacting servers or not.
 
         Returns:
@@ -530,7 +530,7 @@ class API:
 
     def pause_all(self, force: bool = False) -> bool:
         """
-        Remove the given downloads from the list.
+        Pause all (active) downloads.
 
         Arguments:
             force: Whether to pause immediately without contacting servers or not.

--- a/src/aria2p/api.py
+++ b/src/aria2p/api.py
@@ -499,7 +499,7 @@ class API:
 
     def pause(self, downloads: List[Download], force: bool = False) -> List[OperationResult]:
         """
-        Pause (active) the given downloads.
+        Pause the given (active) downloads.
 
         Arguments:
             downloads: The list of downloads to pause.


### PR DESCRIPTION
There is typo in api.py , wrong description for pause and pause_all.