### PR TITLE
Use one session for all posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,17 +509,6 @@ optional arguments:
 
 
 
-
-## Troubleshooting
-
-- Error outputs like below when using `aria2p` as a Python library:
-
-  ```
-  requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=6800): Max retries exceeded with url: /jsonrpc (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1115b1908>: Failed to establish a new connection: [Errno 61] Connection refused',))
-  ```
-
-  Solution: `aria2c` needs to be up and running first.
-
 ## Support
 
 To support me as an open-source software author,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "appdirs>=1.4",
     "loguru>=0.5",
-    "requests>=2.19",
+    "httpx",
     "tomli>=2.0; python_version < '3.11'",
     "websocket-client>=0.58",
 ]

--- a/src/aria2p/api.py
+++ b/src/aria2p/api.py
@@ -44,6 +44,13 @@ class API:
         self.client = client or Client()
         self.listener: threading.Thread | None = None
 
+    def __enter__(self) -> API:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.client.session.close()
+        self.client.session = None
+
     def __repr__(self) -> str:
         return f"API({self.client!r})"
 

--- a/src/aria2p/cli/main.py
+++ b/src/aria2p/cli/main.py
@@ -83,36 +83,43 @@ def main(args: list[str] | None = None) -> int:
     check_args(parser, opts)
 
     logger.debug("Instantiating API")
-    api = API(
+
+    with API(
         Client(
             host=kwargs.pop("host"),
             port=kwargs.pop("port"),
             secret=kwargs.pop("secret"),
             timeout=kwargs.pop("client_timeout"),
-        ),
-    )
+        )
+    ) as api:
+        logger.info(f"API instantiated: {api!r}")
+        # Warn if no aria2 daemon process seems to be running
+        logger.debug("Testing connection")
+        try:
+            api.client.get_version()
+        except httpx.NetworkError as error:
+            print(f"[ERROR] {error}", file=sys.stderr)
+            print(file=sys.stderr)
+            print(
+                "Please make sure that an instance of aria2c is running with RPC mode enabled,",
+                file=sys.stderr,
+            )
+            print(
+                "and that you have provided the right host, port and secret token.",
+                file=sys.stderr,
+            )
+            print(
+                "More information at https://pawamoy.github.io/aria2p.", file=sys.stderr
+            )
+            return 2
 
-    logger.info(f"API instantiated: {api!r}")
+        subcommand = kwargs.pop("subcommand")
+        kwargs.pop("debug_info")
 
-    # Warn if no aria2 daemon process seems to be running
-    logger.debug("Testing connection")
-    try:
-        api.client.get_version()
-    except httpx.NetworkError as error:
-        print(f"[ERROR] {error}", file=sys.stderr)
-        print(file=sys.stderr)
-        print("Please make sure that an instance of aria2c is running with RPC mode enabled,", file=sys.stderr)
-        print("and that you have provided the right host, port and secret token.", file=sys.stderr)
-        print("More information at https://pawamoy.github.io/aria2p.", file=sys.stderr)
-        return 2
-
-    subcommand = kwargs.pop("subcommand")
-    kwargs.pop("debug_info")
-
-    if subcommand:
-        logger.debug("Running subcommand " + subcommand)
-    try:
-        return commands[subcommand](api, **kwargs)  # type: ignore
-    except ClientException as error:
-        print(str(error), file=sys.stderr)
-        return error.code
+        if subcommand:
+            logger.debug("Running subcommand " + subcommand)
+        try:
+            return commands[subcommand](api, **kwargs)  # type: ignore
+        except ClientException as error:
+            print(str(error), file=sys.stderr)
+            return error.code

--- a/src/aria2p/cli/main.py
+++ b/src/aria2p/cli/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import requests
+import httpx
 from loguru import logger
 
 from aria2p import enable_logger
@@ -98,7 +98,7 @@ def main(args: list[str] | None = None) -> int:
     logger.debug("Testing connection")
     try:
         api.client.get_version()
-    except requests.ConnectionError as error:
+    except httpx.NetworkError as error:
         print(f"[ERROR] {error}", file=sys.stderr)
         print(file=sys.stderr)
         print("Please make sure that an instance of aria2c is running with RPC mode enabled,", file=sys.stderr)

--- a/src/aria2p/client.py
+++ b/src/aria2p/client.py
@@ -19,7 +19,7 @@ DEFAULT_ID = -1
 DEFAULT_HOST = "http://localhost"
 DEFAULT_PORT = 6800
 DEFAULT_TIMEOUT: float = 60.0
-DEFAULT_RETRIES = 10
+DEFAULT_RETRIES = 3
 
 JSONRPC_PARSER_ERROR = -32700
 JSONRPC_INVALID_REQUEST = -32600
@@ -205,7 +205,7 @@ class Client:
         self.timeout = timeout
         self.retries = retries
         self.listening = False
-        self.__httpx_session = None
+        self.session = httpx.Client(timeout=self.timeout, transport=httpx.HTTPTransport(retries=self.retries))
 
     def __str__(self):
         return self.server
@@ -214,15 +214,8 @@ class Client:
         return f"Client(host='{self.host}', port={self.port}, secret='********')"
 
     def __del__(self):
-        if self.__httpx_session is not None:
-            self.__httpx_session.close()
-
-    @property
-    def _session(self):
-        if self.__httpx_session is not None:
-            return self.__httpx_session
-        self.__httpx_session = httpx.Client(timeout=self.timeout, transport=httpx.HTTPTransport(verify=False, retries=self.retries))
-        return self.__httpx_session
+        if self.session is not None:
+            self.session.close()
 
     @property
     def server(self) -> str:
@@ -363,7 +356,7 @@ class Client:
         Returns:
             The answer from the server, as a Python dictionary.
         """
-        return self._session.post(self.server, data=payload).json()
+        return self.session.post(self.server, data=payload).json()
 
     @staticmethod
     def response_as_exception(response: dict) -> ClientException:


### PR DESCRIPTION
open/close incase we are using the same session is wrong.

While using threading in some app all requests may done at the same time concurrently if session closed in one of those threads and in another thread still sending post request conflict will happen at that moment and error wil get raised.

so better to keep this one session open after first post request.

better than (create/open/close) if 40 request working concurrently this will happen 40 times, but now it's one session and already opened and no need to close