### PR TITLE
docs: add conda-forge installation instructions for aria2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ can be found in the [Configuration section][conf doc] of the documentation.
 sudo apt-get install aria2
 ```
 
+[*aria2*][1] is also available on `conda-forge`:
+
+```bash
+conda install -c conda-forge aria2
+```
+
 [1]: https://github.com/aria2/aria2
 [2]: https://en.wikipedia.org/wiki/Remote_procedure_call
 

--- a/scripts/templates/README.md
+++ b/scripts/templates/README.md
@@ -75,6 +75,12 @@ You must also install [*aria2*][1]. On systems with `apt-get`:
 sudo apt-get install aria2
 ```
 
+[*aria2*][1] is also available on `conda-forge`:
+
+```bash
+conda install -c conda-forge aria2
+```
+
 [1]: https://github.com/aria2/aria2
 [2]: https://en.wikipedia.org/wiki/Remote_procedure_call
 


### PR DESCRIPTION
Closes #140

Add `conda-forge` as an alternative installation method for aria2 in the Requirements section.

This is helpful for:
- Users without sudo permissions who need to install aria2
- Users already managing their Python environment with conda